### PR TITLE
Add external-dns

### DIFF
--- a/gitops/app/default/blog/blog.yaml
+++ b/gitops/app/default/blog/blog.yaml
@@ -18,8 +18,14 @@ spec:
     ingress:
       enabled: true
       annotations:
+        kubernetes.io/ingress.class: nginx
+        external-dns: public
+        external-dns.alpha.kubernetes.io/hostname: timtorchen.com,www.timtorchen.com
+        external-dns.alpha.kubernetes.io/target: cname.timtorchen.com
       hosts:
       - host: timtorchen.com
+        paths: [/]
+      - host: www.timtorchen.com
         paths: [/]
     
     serviceAccount:

--- a/gitops/app/ingress-system/servicemonitor.yaml
+++ b/gitops/app/ingress-system/servicemonitor.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -12,3 +13,18 @@ spec:
       app.kubernetes.io/name: ingress-nginx
   endpoints:
     - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: ingress-system
+  name: external-dns
+spec:
+  namespaceSelector:
+    matchNames:
+      - ingress-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+  endpoints:
+    - port: http

--- a/gitops/app/monitor-system/grafana.yaml
+++ b/gitops/app/monitor-system/grafana.yaml
@@ -20,6 +20,9 @@ spec:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
+        external-dns: public
+        external-dns.alpha.kubernetes.io/hostname: grafana.timtorchen.com
+        external-dns.alpha.kubernetes.io/target: cname.timtorchen.com
       hosts:
         - grafana.timtorchen.com
     persistence:

--- a/gitops/crd/external-dns.yaml
+++ b/gitops/crd/external-dns.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  namespace: flux-system
+  name: external-dns-crd-source
+spec:
+  interval: 5m
+  url: https://github.com/kubernetes-sigs/external-dns
+  ref: 
+    tag: v0.7.6
+  ignore: |
+    # exclude all
+    /*
+    # include crd
+    !/docs/contributing/crd-source/crd-manifest.yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  namespace: flux-system
+  name: external-dns-crd
+spec:
+  interval: 10m
+  prune: true
+  sourceRef: 
+    kind: GitRepository
+    name: external-dns-crd-source
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: dnsendpoints.externaldns.k8s.io

--- a/gitops/infra/ingress-system/external-dns.yaml
+++ b/gitops/infra/ingress-system/external-dns.yaml
@@ -1,0 +1,41 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  namespace: ingress-system
+  name: external-dns
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: bitnami
+      # renovate: registryUrl=https://charts.bitnami.com/bitnami
+      chart: external-dns
+      version: 4.9.1
+  interval: 1h
+  values:
+    image:
+      registry: k8s.gcr.io
+      repository: external-dns/external-dns
+      tag: v0.7.6
+    sources:
+      - crd
+      - ingress
+    annotationFilter: external-dns in (public)
+    domainFilters:
+      - timtor.dev
+      - timtorchen.com
+    provider: cloudflare
+    cloudflare:
+      secretName: cloudflare-secret
+      proxied: true
+    policy: sync
+    crd:
+      create: false
+      apiversion: externaldns.k8s.io/v1alpha1
+      kind: DNSEndpoint
+    rbac:
+      create: true
+    serviceAccount:
+      create: true

--- a/gitops/infra/ingress-system/secret.yaml
+++ b/gitops/infra/ingress-system/secret.yaml
@@ -5,41 +5,87 @@ metadata:
     name: cloudflare-api-token
 type: Opaque
 data:
-    api-token: ENC[AES256_GCM,data:dDwr9709lsbmkKdaqVez6r9TchvkBko/nqP5FZAwWiaMvRzMQ6lPRKMhAurWnlHJng5kv94myT4=,iv:i4+NmYA0TwGEvCdcTZ0ftV+umm8YDMqmyICVntp51n0=,tag:AMdpsCPrxasfe3QTsaNCHg==,type:str]
-    #ENC[AES256_GCM,data:UQ5+QE3Kab6/chs75vnckopEcevVI07vxlv8bGhqhGD+Z9rXTysmcKI=,iv:sVoUCRgWqjb4JXpu1i7RM3seckDwuKeDIsO1NlwIQGM=,tag:w5cL6Qpf/wEdrfLa7IefuA==,type:comment]
+    api-token: ENC[AES256_GCM,data:ZfnYOs1LLk+C8Xn2iRyWn85BfKw0Bhqdam5AXZ8Bz3r8dQn8r+uaVqcJY3QppOHO7+otJ82XN9M=,iv:x/Sq6oKy57Q4B3TM2OSyCa1O9HqFcVpPW5eVRRpAJQA=,tag:HUDIyXGyqjpySOxBsW3KYw==,type:str]
+    #ENC[AES256_GCM,data:xHpA1/O5bQJCi35xMvQc/YjAgm3t412yNaj62jRwfVpgf6Zufv4+K0Y=,iv:597+fD7E3O4VXv90nPgh0oCdXlB8Xqi9mmS/G7j2qR8=,tag:UQxzvVEFKpliBSGNtZ2ouw==,type:comment]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-10T10:42:48Z'
-    mac: ENC[AES256_GCM,data:3zimCtLYcmrL9e5Ax5+KZu8SmkUzQ/Hs8EXJau6KVVq/TqmWcZP43b1R0NzQ60RAKWVI2kLjCUXy5fDPTDn/lwF6yPL7B93bQkOc4P2AfOxES25hSXgalsRfmkCWOg8+BKqHWp/0/y8xeYt/317W0sVS6GR4l7DnHa5HAm7Lgro=,iv:h+8p9F2SqnGvSOjEnRlXW3ruMO/0jCNph/xv0npqshs=,tag:iCqupYHMj653A3RHjj4qZw==,type:str]
+    lastmodified: '2021-03-18T07:05:14Z'
+    mac: ENC[AES256_GCM,data:PqNGUdnsawFVm5XssGWhVP38h5StG4nW997hB6+FXLJ7QKQ/hN9xMvEcfve+NsktwT/MmsHu9QgIL9okEtAb/2u5Fq2pWMVffL4kVkOZrSRKzVZ8BJQgGru8NJDszggW5ms/EAVvEmVvvWYALWm1VvmlaTnuL1OadoCCpj8m/DQ=,iv:+jok9SbhccaI1JVBmyfv4v6WrvalwjGZzyEXydNYOo4=,tag:YujAHFd0Wx2ovSIfxXIP4w==,type:str]
     pgp:
-    -   created_at: '2021-03-10T10:42:47Z'
+    -   created_at: '2021-03-18T07:05:11Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQMOA7Xwm0UuZgqEEAv+MCl48M/pLolbNBhLXuKnSw8B7wzhDOasG2Xo6qYBdmc8
-            Hmysf/hpyisUawxXnTC6VpgxiMH/sk8tZ4zvTrI4tfTzPjY4ixNr4XJeVOcE7eEv
-            kQzXqMOgC/V/TYwnWNOO79yD8QIbsznSaOuunLtqcjfm7l76vNTs9WsgCbWRLpMT
-            8ojRkI/PMp5aiL91W5s6vncZkj1DOnCIt7BBBYftK5sqObHnal5gLdN1LGhRELeE
-            AOt6V9D0WmGjj+Fgdm3ICF435sDxQjY2WqjrtskUtvPOa8Q+3nIqjSBb/pZqxkj7
-            bbV++oos7Sz0Z+ezfmwm2xnHQDQhCYTYcMXNQgeKg9em9JNRXzl/TjJk7XFqp4W5
-            OKITu0v78fPx2GebEmDAz2kBKhlullv2gaIkpswtmuO6+p1ptkRWMRk2c7oqQjHG
-            Lp9PfvmoZz7mws7BlVWEim9M3BuwVsLxzp1Wii5zgCNauuvjuc38CtkPwPCFe6q7
-            ZiVTRR3zjp+Tnb+h4YStDACjJValW01A+DDBf+TMQkKnIX49ntU0ZiqrPBbchQ8v
-            Rce5VBi0dD4yQ948/gzVWcGfho36NRMUZE7/Uz5DrmSPbH84XX64QVea9athP5LZ
-            ptT1UtzNL2MDkGi2Rt2w4f3h9MAIZCcew4zXMYdRjC7042aGDdECtMyNK7oqtpqa
-            OoKOkRhhgDlvc5f8WoxcsfpwegbEhA2MIviZbe8g2QElHAg0ncTB+TixH2vD3EdU
-            9j5pYIZVSF36QIQcRlaZD+aXEYlD8a06hyBBEI3qR18+MDFgosIuwcKkjbfKAk3w
-            AogJlF4tXNYuGvSzbtsHWJJ8efQyLXU9xingcw2kz6Ro1mEPNQ7e++qJz56gPPmA
-            MEHzUtcRBpgagcHmryzXFWUiUYssQPyoqiUog2DL0dS3HUJHxDi8bVA6nIlcyeNJ
-            Tlt0dfN/n9pW1bGKg49aar2HECTM44UHRzxeL25kTCTFHoV4q7DPt61vIP6kEdMu
-            mxTLfKiaxtKs26rwxGLydmrSXgH9cVwSp85UTPBI3zFyaDUPos7PBUOirlFXXGXC
-            HJilAbLGga4kfaUjiqcVralshvZ+0nO6TVrRd8dVqYSQKQiXPBZpozv9PCd6b2Uo
-            CCFN46ykC+xmP4e42HaktH8=
-            =Vbl3
+            hQMOA7Xwm0UuZgqEEAwAnmWiKsveJCej+Zu71J9C+LHrUwe3qTolaQrmywMAQow+
+            Ei7n+b9b6aJeb1B/KrX2paMd1jAAq+urM+XCxQpEXNMFzTmV7quGqamwgx6E1OXK
+            ENg8mPyTQTIrg+xhe4C5NPxfh3j9WPYFtdmFjKrL8FjiRNg8MSh7Ud1kwXYfZwp/
+            SAkJk2+szUkw6Q7pAGx0KGx5MhV7VbmN5pGlNqV5iKz/OqMY0t63EMRhPV4sD4Uf
+            pTJrjCLhIZJ+MTnpurVKLb4WZBjDgeUUav4cVQrgJ9vSaHqd/DsQGd/ekbrmu8be
+            ngxwbzAvqXIiEQmNKj6kwOnvkt6JBsthTECM5IbdsXk7RcYL+BbjJ1+k37UhcEsf
+            HxSBrmBRv26TA+SNIv9A6cHbNatvmB9Zl0sS2bZ0Ti5PXGdEYIxSjxftup+DC2NS
+            mMuN7yZ51kGA2BsHWDTrUAhDr6AZNEEIWNtIkIf3dVYO73ezih2WHoRkbWnBM+zL
+            faNFyYcBgO4wr+RRoRudDADK7dQhZGVZ5/mNQEQDN8fT06gYa0HlWy3si1KfnnsZ
+            3+VgSlEeqeDDnaf9WJBHJ1f9R/xhnQBg3jZul6FnnAxmSPQp0w8jv+4wft6ikUwD
+            fHA5/0056kTKK1ptuaQsGnitF9acR5wE2HLTuOyCPlJcOY9RXaesv9wuKsLLKVCp
+            nHBGls8rOsCrLY8T6MxPs0kQ2Af8uH9A//z/XnDZa2Rrcxvd2lhARQFiWGRl9/JT
+            yMAddzsgf5mvSf2tmgxjre4+krJN7goU+hVIEXsXzJL6ero8urmjm0yDP1lkrmzT
+            i+o44h/L2MUInXLknNbGYHyEcJeRBbgunA8A+IuwCMpX/FD5TU/df623CZBtBD9n
+            WHxx+YFTMv/qRZr0pgGQ1fKWKjkGi6hFmXavAsbbus72jvbtB7pX9dCeQgR7D7Ld
+            ODhFMYzRPBz2C3vxLcIDJm5n0Dyv7jWwpF4gCtApnvktKrbBO5pUicxHoxGdBIfT
+            ESwaOJ5hBW9Exu4+6hhhn/fSXgFGSNWp5cADi63DflBc+bN8/Ea1Z2c/Ht7m9e7g
+            zKJYUZnKKDu3Hye/1rJWDdr9bZOgkldLtM/KYK2AJt6KJ3b4ovVbNWbmPlprJiyT
+            ZkoKQmE74VnS0gkAp+Q7Z3k=
+            =Fmv0
             -----END PGP MESSAGE-----
         fp: B5F09B452E660A84
-    encrypted_regex: (^data$|^stringData$|user|[Pp]assword)
+    encrypted_regex: (^data$|^stringData$|user|[Pp]assword|userDatabase)
+    version: 3.6.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    namespace: ingress-system
+    name: cloudflare-secret
+type: Opaque
+data:
+    cloudflare_api_token: ENC[AES256_GCM,data:kPKzUiDXYX6AegSxD9H4nJtVj1ra2cF6o87UOlSIF8rssf0/EZk+e+hzTjgcj4CJCsKqPLnFnRw=,iv:E1mDt0CY4bZAzLOLiAzIYJNgxL9FSV9op0xhNf4eILM=,tag:P4KEwRqlKbyZFUCKqu/BMg==,type:str]
+    #ENC[AES256_GCM,data:xutg9apSgIEsUXXh59z7JKApACBvW+e+x2ZXiaewvYbDYw2gW/CYROg=,iv:d1nYGDcgg4y0917Y4mm/ZLwrxd7cmLOgMI6jVTBCjUM=,tag:m9+igdRqU1sqMw/eDxbfmQ==,type:comment]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-03-18T07:05:14Z'
+    mac: ENC[AES256_GCM,data:PqNGUdnsawFVm5XssGWhVP38h5StG4nW997hB6+FXLJ7QKQ/hN9xMvEcfve+NsktwT/MmsHu9QgIL9okEtAb/2u5Fq2pWMVffL4kVkOZrSRKzVZ8BJQgGru8NJDszggW5ms/EAVvEmVvvWYALWm1VvmlaTnuL1OadoCCpj8m/DQ=,iv:+jok9SbhccaI1JVBmyfv4v6WrvalwjGZzyEXydNYOo4=,tag:YujAHFd0Wx2ovSIfxXIP4w==,type:str]
+    pgp:
+    -   created_at: '2021-03-18T07:05:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQMOA7Xwm0UuZgqEEAwAnmWiKsveJCej+Zu71J9C+LHrUwe3qTolaQrmywMAQow+
+            Ei7n+b9b6aJeb1B/KrX2paMd1jAAq+urM+XCxQpEXNMFzTmV7quGqamwgx6E1OXK
+            ENg8mPyTQTIrg+xhe4C5NPxfh3j9WPYFtdmFjKrL8FjiRNg8MSh7Ud1kwXYfZwp/
+            SAkJk2+szUkw6Q7pAGx0KGx5MhV7VbmN5pGlNqV5iKz/OqMY0t63EMRhPV4sD4Uf
+            pTJrjCLhIZJ+MTnpurVKLb4WZBjDgeUUav4cVQrgJ9vSaHqd/DsQGd/ekbrmu8be
+            ngxwbzAvqXIiEQmNKj6kwOnvkt6JBsthTECM5IbdsXk7RcYL+BbjJ1+k37UhcEsf
+            HxSBrmBRv26TA+SNIv9A6cHbNatvmB9Zl0sS2bZ0Ti5PXGdEYIxSjxftup+DC2NS
+            mMuN7yZ51kGA2BsHWDTrUAhDr6AZNEEIWNtIkIf3dVYO73ezih2WHoRkbWnBM+zL
+            faNFyYcBgO4wr+RRoRudDADK7dQhZGVZ5/mNQEQDN8fT06gYa0HlWy3si1KfnnsZ
+            3+VgSlEeqeDDnaf9WJBHJ1f9R/xhnQBg3jZul6FnnAxmSPQp0w8jv+4wft6ikUwD
+            fHA5/0056kTKK1ptuaQsGnitF9acR5wE2HLTuOyCPlJcOY9RXaesv9wuKsLLKVCp
+            nHBGls8rOsCrLY8T6MxPs0kQ2Af8uH9A//z/XnDZa2Rrcxvd2lhARQFiWGRl9/JT
+            yMAddzsgf5mvSf2tmgxjre4+krJN7goU+hVIEXsXzJL6ero8urmjm0yDP1lkrmzT
+            i+o44h/L2MUInXLknNbGYHyEcJeRBbgunA8A+IuwCMpX/FD5TU/df623CZBtBD9n
+            WHxx+YFTMv/qRZr0pgGQ1fKWKjkGi6hFmXavAsbbus72jvbtB7pX9dCeQgR7D7Ld
+            ODhFMYzRPBz2C3vxLcIDJm5n0Dyv7jWwpF4gCtApnvktKrbBO5pUicxHoxGdBIfT
+            ESwaOJ5hBW9Exu4+6hhhn/fSXgFGSNWp5cADi63DflBc+bN8/Ea1Z2c/Ht7m9e7g
+            zKJYUZnKKDu3Hye/1rJWDdr9bZOgkldLtM/KYK2AJt6KJ3b4ovVbNWbmPlprJiyT
+            ZkoKQmE74VnS0gkAp+Q7Z3k=
+            =Fmv0
+            -----END PGP MESSAGE-----
+        fp: B5F09B452E660A84
+    encrypted_regex: (^data$|^stringData$|user|[Pp]assword|userDatabase)
     version: 3.6.1

--- a/gitops/source/helmrepo.yaml
+++ b/gitops/source/helmrepo.yaml
@@ -158,3 +158,13 @@ metadata:
 spec:
   url:  https://charts.drone.io 
   interval: 24h
+---
+# bitnami
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  namespace: flux-system
+  name: bitnami
+spec:
+  url: https://charts.bitnami.com/bitnami
+  interval: 24h


### PR DESCRIPTION
### Description
Use external-dns to control cloudflare record for public services, like https://github.com/kubernetes-sigs/external-dns/issues/1394#issuecomment-585228684 mentioned. 

I have one static IP provided by ISP, and here is my steps:
1. Manually create an A record `cname.timtorchen.com` point to `IP address` 
2. Restrict external-dns by `annotationFilter` to only create record for Ingress who have `external-dns: public` annotation, mentioned at https://github.com/kubernetes-sigs/external-dns/issues/1100#issuecomment-511411600
```
--annotation-filter=external-dns in (public)
```
3. Annotate a Ingress telling external-dns to create a CANME points `subdomain.timtorchen.com` to `cname.timtorchen.com`

```
ingress:
    annotations:
        kubernetes.io/ingress.class: nginx
        external-dns: public 
        external-dns.alpha.kubernetes.io/hostname: subdomain.timtorchen.com
        external-dns.alpha.kubernetes.io/target: cname.timtorchen.com
```
